### PR TITLE
Changes to determine os_type

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1140,7 +1140,7 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     win_installer = config.get_cloud_config_value(
         'win_installer', vm_, __opts__, search_global=True
     )
-     os_type = config.get_cloud_config_value(
+    os_type = config.get_cloud_config_value(
         'os_type', vm_, __opts__, search_global=True
     )
     if vm_['image'].startswith('http'):

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1140,14 +1140,17 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     win_installer = config.get_cloud_config_value(
         'win_installer', vm_, __opts__, search_global=True
     )
+     os_type = config.get_cloud_config_value(
+        'os_type', vm_, __opts__, search_global=True
+    )
     if vm_['image'].startswith('http'):
         # https://{storage_account}.blob.core.windows.net/{path}/{vhd}
         source_image = VirtualHardDisk(vm_['image'])
         img_ref = None
-        if win_installer:
-            os_type = 'Windows'
-        else:
-            os_type = 'Linux'
+        if not os_type:
+                raise SaltCloudSystemExit(
+                'os_type must be specified in case of custom vhd'
+                )
     else:
         img_pub, img_off, img_sku, img_ver = vm_['image'].split('|')
         source_image = None


### PR DESCRIPTION
### What does this PR do?
Fixes the way to determine os type
### What issues does this PR fix or reference?
#44886
### Previous Behavior
os_type was determined from presence of win_installer. But when deploy is set to false there is not need to mention win_installer in salt profile.  Because of this for custom images irrespective of type of os, os_type was being set to linux and hence provisioning used to fail (when deploy is set to false).
Market place images worked fine

### New Behavior
os_type i made mandatory to be specified in case of custom images or vhd.

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
